### PR TITLE
Rename panel

### DIFF
--- a/chrome/scripts/devtools.js
+++ b/chrome/scripts/devtools.js
@@ -1,1 +1,1 @@
-chrome.devtools.panels.create('Meteor DevTools', 'assets/icons/icon16.png', 'panel.html');
+chrome.devtools.panels.create('Meteor', 'assets/icons/icon16.png', 'panel.html');


### PR DESCRIPTION
I suggest shortening the label to be a single word like most other panels, including React DevTools, which just says "React". This also helps more tabs fit on my tiny 13" Macbook screen without them overflowing and having to click the little arrow to show them :)