### PR TITLE
Typo in mdg:validated-method

### DIFF
--- a/src/plugins/security/components/package-audit.js
+++ b/src/plugins/security/components/package-audit.js
@@ -51,7 +51,7 @@ export default React.createClass({
             {this._checkPackageIsRemoved('autopublish')}
             {this._checkPackageIsIncluded('aldeed:simple-schema')}
             {this._checkPackageIsIncluded('audit-argument-checks')}
-            {this._checkPackageIsIncluded('mdg:validated-methods')}
+            {this._checkPackageIsIncluded('mdg:validated-method')}
         </ul>
       </div>
     )


### PR DESCRIPTION
The package's name is `mdg:validated-method` without the `s`.

See: https://atmospherejs.com/mdg/validated-method